### PR TITLE
feat: search endpoint

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -17,6 +17,17 @@ functions:
             parameters:
               paths:
                 id: true
+  searchProfiles:
+    handler: src/functionHandlers/searchProfiles/index.handler
+    events:
+      - http:
+          path: /search
+          method: get
+          cors: true
+          request:
+            parameters:
+              paths:
+                id: true
 
 custom:
   webpack:

--- a/serverless.yml
+++ b/serverless.yml
@@ -24,10 +24,6 @@ functions:
           path: /search
           method: get
           cors: true
-          request:
-            parameters:
-              paths:
-                id: true
 
 custom:
   webpack:

--- a/src/functionHandlers/searchProfiles/index.ts
+++ b/src/functionHandlers/searchProfiles/index.ts
@@ -1,0 +1,1 @@
+export * from "./searchProfiles";

--- a/src/functionHandlers/searchProfiles/searchProfiles.ts
+++ b/src/functionHandlers/searchProfiles/searchProfiles.ts
@@ -1,0 +1,45 @@
+import { APIGatewayEvent } from "aws-lambda";
+import createHttpError from "http-errors";
+import { restrictedRequestHandler } from "../../middlewares/handlers";
+import { sheetsToJson } from "../../services/sheets";
+import { config } from "../../config";
+import { memoize } from "../../common/utils";
+
+interface Identity {
+  name: string;
+  remarks: string;
+  identifier: string;
+}
+
+interface Identities {
+  [identifier: string]: Identity;
+}
+
+const searchProfiles = async (event: APIGatewayEvent) => {
+  const query = event.queryStringParameters?.q;
+  if (!query) throw new createHttpError.BadRequest("Query string is not defined");
+  if (query.length < 3) throw new createHttpError.BadRequest("Query string needs to be at least 3 characters");
+
+  const lowercaseQuery = query.toLowerCase();
+
+  const identities = await memoize(
+    () =>
+      sheetsToJson<Identities>({
+        id: config.sheetsId,
+        range: config.sheetsRange,
+        keyBy: "identifier"
+      }),
+    "IDENTITIES"
+  );
+
+  return Object.keys(identities)
+    .map(address => identities[address])
+    .filter(
+      identity =>
+        identity.name.toLowerCase().includes(lowercaseQuery) ||
+        identity.remarks.toLowerCase().includes(lowercaseQuery) ||
+        identity.identifier.toLowerCase().includes(lowercaseQuery)
+    );
+};
+
+export const handler = restrictedRequestHandler(searchProfiles);


### PR DESCRIPTION
## Search Endpoint

Story: https://www.pivotaltracker.com/story/show/173396304

Creates an endpoint at `/search` to allow for a query like:

```sh
GET /search?q=abc 
```

This will return all results with the query `abc` in any of the name, identifier or remarks. 
